### PR TITLE
Light control user experience improvements. 

### DIFF
--- a/plugins/light_control/Main.cpp
+++ b/plugins/light_control/Main.cpp
@@ -317,7 +317,10 @@ namespace Plugins::LightControl
 		if (const auto subCommand = GetParam(param, ' ', 0); subCommand == L"change")
 		{
 			if (!IsInValidBase(client))
+			{
 				return;
+			}
+
 			UserCmdChangeItem(client, param);
 		}
 		else if (subCommand == L"show")

--- a/plugins/light_control/Main.cpp
+++ b/plugins/light_control/Main.cpp
@@ -8,7 +8,7 @@
  * @paragraph cmds Player Commands
  * All commands are prefixed with '/' unless explicitly specified.
  * - lights show - Shows the current equipped lights.
- * - lights options - Shows what lights you can equip.
+ * - lights options <Page Number> - Shows a page of lights that can be swapped to.
  * - lights change <Light Point> <Item> - Swap a light.
  *
  * @paragraph adminCmds Admin Commands
@@ -22,6 +22,7 @@
  *     "introMessage1": "Light customization facilities are available here.",
  *     "introMessage2": "Type /lights on your console to see options.",
  *     "lights": ["SmallWhite","LargeGreen"],
+ *     "itemsPerPage": 10,
  *     "notifyAvailabilityOnEnter": false
  * }
  * @endcode
@@ -134,6 +135,12 @@ namespace Plugins::LightControl
 
 			lights.emplace_back(i);
 		}
+		if (lights.empty())
+		{
+			PrintUserCmdText(client, L"Error: You have no valid hard points that can be changed. ");
+			return;
+		}
+
 		std::ranges::sort(lights, [](const EquipDesc& a, const EquipDesc& b) { return a.get_hardpoint().value < b.get_hardpoint().value; });
 
 		int itemNumber = 1;
@@ -157,6 +164,12 @@ namespace Plugins::LightControl
 	 */
 	void UserCmdListLights(ClientId& client, const std::wstring& param)
 	{
+		if ( global->config->lights.empty())
+		{
+			PrintUserCmdText(client, L"Error: There are no available options. ");
+			return;
+		}
+
 		const uint pageNumber = ToUInt(GetParam(param, ' ', 1)) - 1;
 		const uint lightsSize = static_cast<int>(global->config->lights.size());
 
@@ -217,6 +230,11 @@ namespace Plugins::LightControl
 			}
 
 			lights.emplace_back(i);
+		}
+		if (lights.empty())
+		{
+			PrintUserCmdText(client, L"Error: You have no valid hard points that can be changed. ");
+			return;
 		}
 
 		std::ranges::sort(lights, [](const EquipDesc& a, const EquipDesc& b) { return a.get_hardpoint().value < b.get_hardpoint().value; });

--- a/plugins/light_control/Main.h
+++ b/plugins/light_control/Main.h
@@ -28,6 +28,9 @@ namespace Plugins::LightControl
 		//! cost per changed item.
 		uint cost = 0;
 
+		//For display lights, how many to display.
+		uint itemsPerPage = 25;
+
 		//! Map of bases who offer LightControl
 		std::vector<std::string> bases;
 		std::vector<uint> baseIdHashes;

--- a/plugins/light_control/Main.h
+++ b/plugins/light_control/Main.h
@@ -28,8 +28,8 @@ namespace Plugins::LightControl
 		//! cost per changed item.
 		uint cost = 0;
 
-		//For display lights, how many to display.
-		uint itemsPerPage = 25;
+		//!For options command, how many items to display.
+		uint itemsPerPage = 24;
 
 		//! Map of bases who offer LightControl
 		std::vector<std::string> bases;


### PR DESCRIPTION
'/light options' now has a page system implemented, defaulted to 25 per page.
'/lights show'  & '/lights change' now have the hardpoint list sorted by id and won't change between edits.
'/lights change' now supports changing multiple lights via  '/lights change x1-x2-x3-. . . xn <Light Option>' to change listed hardpoints or '/lights all <Light Option> to change all possible hardpoints.

Error checking to see if user has valid hard points to change or if configuration has anything listed. 