### PR TITLE
fix: renaming SpinProtection. CrashFix.

### DIFF
--- a/plugins/npc_spin_protection/Main.cpp
+++ b/plugins/npc_spin_protection/Main.cpp
@@ -26,7 +26,7 @@
 // Includes
 #include "Main.h"
 
-namespace Plugins::SpinProtection
+namespace Plugins::NPCSpinProtection
 {
 	const std::unique_ptr<Global> global = std::make_unique<Global>();
 
@@ -40,7 +40,7 @@ namespace Plugins::SpinProtection
 	void SPObjCollision(struct SSPObjCollisionInfo const& ci, ClientId& client)
 	{
 		// If spin protection is off, do nothing.
-		if (global->config->spinProtectionMass == -1.0f)
+		if (ci.iColliderObjectId == 0 || global->config->spinProtectionMass == -1.0f)
 			return;
 
 		float targetMass = Hk::Solar::GetMass(ci.iColliderObjectId).value();
@@ -77,12 +77,12 @@ namespace Plugins::SpinProtection
 		V2.z *= global->config->spinImpulseMultiplier * clientMass;
 		pub::SpaceObj::AddImpulse(ci.iColliderObjectId, V1, V2);
 	}
-} // namespace Plugins::SpinProtection
+} // namespace Plugins::NPCSpinProtection
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // FLHOOK STUFF
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
-using namespace Plugins::SpinProtection;
+using namespace Plugins::NPCSpinProtection;
 
 DefaultDllMainSettings(LoadSettings);
 

--- a/plugins/npc_spin_protection/Main.h
+++ b/plugins/npc_spin_protection/Main.h
@@ -3,7 +3,7 @@
 #include <FLHook.hpp>
 #include <plugin.h>
 
-namespace Plugins::SpinProtection
+namespace Plugins::NPCSpinProtection
 {
 	//! Config data for this plugin
 	struct Config : Reflectable
@@ -15,7 +15,7 @@ namespace Plugins::SpinProtection
 		float spinImpulseMultiplier = -1.0f;
 
 		//! File location of the json config file
-		std::string File() override { return "config/spin_protection.json"; }
+		std::string File() override { return "config/npc_spin_protection.json"; }
 	};
 
 	//! Global data for this plugin

--- a/plugins/npc_spin_protection/NPC Spin Protection.vcxproj
+++ b/plugins/npc_spin_protection/NPC Spin Protection.vcxproj
@@ -12,10 +12,10 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{B7E11334-9268-4963-8787-C843A9031230}</ProjectGuid>
-    <RootNamespace>spin_protection</RootNamespace>
+    <RootNamespace>npc_spin_protection</RootNamespace>
     <Keyword>Win32Proj</Keyword>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
-    <ProjectName>Spin Protection</ProjectName>
+    <ProjectName>NPC Spin Protection</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
@@ -44,10 +44,10 @@
     <Import Project="..\Plugin Common.props" />
   </ImportGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <TargetName>spin_protection_plugin</TargetName>
+    <TargetName>npc_spin_protection</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseWithDebug|Win32'">
-    <TargetName>spin_protection_plugin</TargetName>
+    <TargetName>npc_spin_protection</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -55,7 +55,8 @@
       <LanguageStandard>stdcpp20</LanguageStandard>
       <ConformanceMode>true</ConformanceMode>
       <EnableModules>true</EnableModules>
-      <DisableSpecificWarnings>5222</DisableSpecificWarnings>    </ClCompile>
+      <DisableSpecificWarnings>5222</DisableSpecificWarnings>
+    </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseWithDebug|Win32'">
     <ClCompile>
@@ -63,7 +64,8 @@
       <LanguageStandard>stdcpp20</LanguageStandard>
       <ConformanceMode>true</ConformanceMode>
       <EnableModules>true</EnableModules>
-      <DisableSpecificWarnings>5222</DisableSpecificWarnings>    </ClCompile>
+      <DisableSpecificWarnings>5222</DisableSpecificWarnings>
+    </ClCompile>
   </ItemDefinitionGroup>
   <PropertyGroup Label="Vcpkg">
     <VcpkgEnableManifest>true</VcpkgEnableManifest>

--- a/project/FLHook.sln
+++ b/project/FLHook.sln
@@ -62,7 +62,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Wardrobe", "..\plugins\wardrobe\Wardrobe.vcxproj", "{1BB57539-858B-4AB7-994E-401597653E64}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Spin Protection", "..\plugins\spin_protection\Spin Protection.vcxproj", "{B7E11334-9268-4963-8787-C843A9031230}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "NPC Spin Protection", "..\plugins\npc_spin_protection\NPC Spin Protection.vcxproj", "{B7E11334-9268-4963-8787-C843A9031230}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Need Client Hook", "Need Client Hook", "{F715265D-4DBB-43B1-A159-979B912D095B}"
 EndProject


### PR DESCRIPTION
Now named NPC Spin Protection.
Fixes Exceptions thrown when player collides with ship debris and other temporary objects.