### PR TITLE
Fix Autobuy target name for Release

### DIFF
--- a/plugins/autobuy/autobuy.vcxproj
+++ b/plugins/autobuy/autobuy.vcxproj
@@ -44,7 +44,7 @@
     <Import Project="..\Plugin Common.props" />
   </ImportGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <TargetName>$safeprojectname$</TargetName>
+    <TargetName>autobuy</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseWithDebug|Win32'">
     <TargetName>autobuy</TargetName>


### PR DESCRIPTION
This was causing the autobuy.dll file to not be included in our automated CI builds