### PR TITLE
Fixed no base entry beaming to the Manchester Asteroid Miner

### DIFF
--- a/source/CCmds.cpp
+++ b/source/CCmds.cpp
@@ -844,6 +844,12 @@ void CCmds::CmdBeam(const std::variant<uint, std::wstring>& player, const std::w
 
 	try
 	{
+		if (Trim(targetBaseName).empty())
+		{
+			PrintError(Error::InvalidBaseName);
+			return;
+		}
+
 		const auto base = Hk::Solar::GetBaseByWildcard(targetBaseName);
 		if (base.has_error())
 		{

--- a/source/CCmds.cpp
+++ b/source/CCmds.cpp
@@ -861,7 +861,6 @@ void CCmds::CmdBeam(const std::variant<uint, std::wstring>& player, const std::w
 		if (res.has_error())
 		{
 			PrintError(res.error());
-			return;
 		}
 	}
 	catch (...)


### PR DESCRIPTION
Simple check to see if the target base string in admin commands beam is empty and return an invalid base error if so. 