### PR TITLE
Admin beam and light control bug fix

### DIFF
--- a/plugins/light_control/LightControl.cpp
+++ b/plugins/light_control/LightControl.cpp
@@ -287,7 +287,6 @@ namespace Plugins::LightControl
 				return;
 			}
 
-
 			const auto& selectedLightEquipDesc = lights[hardPointId];
 
 			const auto light = std::find_if(

--- a/plugins/light_control/LightControl.cpp
+++ b/plugins/light_control/LightControl.cpp
@@ -281,6 +281,13 @@ namespace Plugins::LightControl
 			}
 
 			const auto lightId = CreateID(wstos(selectedLight).c_str());
+			if (std::ranges::find(global->config->lightsHashed, lightId) == global->config->lightsHashed.end())
+			{
+				PrintUserCmdText(client, std::format(L"ERR: {} is not a valid option", selectedLight));
+				return;
+			}
+
+
 			const auto& selectedLightEquipDesc = lights[hardPointId];
 
 			const auto light = std::find_if(

--- a/source/CCmds.cpp
+++ b/source/CCmds.cpp
@@ -844,6 +844,12 @@ void CCmds::CmdBeam(const std::variant<uint, std::wstring>& player, const std::w
 
 	try
 	{
+		if (Hk::Player::GetCurrentBase(player).has_value())
+		{
+			Print("Err: Target is currently in a base and unable to be beamed");
+			return;
+		}
+
 		if (Trim(targetBaseName).empty())
 		{
 			PrintError(Error::InvalidBaseName);


### PR DESCRIPTION
Fixes two of the bugs we discovered in the Anniversary event. 
1.) Admin beam command will no longer kick someone if attempted to use on a docked player, simply just fails and notifies the admin.
2.) Light control checks to make sure the option they want to change to is a valid one in the list. 