### PR TITLE
Adjust cargo drop to allow server owners to specify as many 'hull' drop commodities as they like on player death.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.0.4
+
+- Changed CargoDrop plugin to accept more than two commodities, amount of Hull drops now calculcated by mass rather than ship hold size.
+
 ## 4.0.3
 
 - Fixed exceptions on JumpInComplete hook due to improper parameter count.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
 ## 4.0.5
+
 - Changed CargoDrop plugin to accept more than two commodities, amount of Hull drops now calculcated by mass rather than ship hold size.
 
 ## 4.0.4
+
 - Update autobuy to cover miscellaneous ammo types if they are present (HP_GUN).
 
 ## 4.0.3

--- a/plugins/cargo_drop/CargoDrop.cpp
+++ b/plugins/cargo_drop/CargoDrop.cpp
@@ -165,7 +165,7 @@ namespace Plugins::CargoDrop
 		if (const auto hullDropTotal = int(global->config->hullDropFactor * float(ship->fMass)); hullDropTotal > 0)
 		{
 			if (FLHookConfig::i()->general.debugMode)
-				Console::ConDebug(std::format("Cargo drop in system {:#X} at {:.2f}, {:.2f}, {:.2f} for ship size of shipSizeEst={} iHullDrop={}\n",
+				Console::ConDebug(std::format("Cargo drop in system {:#X} at {:.2f}, {:.2f}, {:.2f} for ship size of shipMass={} iHullDrop={}\n",
 				    system,
 				    position.x,
 				    position.y,

--- a/plugins/cargo_drop/CargoDrop.cpp
+++ b/plugins/cargo_drop/CargoDrop.cpp
@@ -162,7 +162,7 @@ namespace Plugins::CargoDrop
 				}
 			}
 		}
-		if (const auto hullDropTotal = static_cast<int>(global->config->hullDropFactor * static_cast<float>(ship->fMass)); hullDropTotal > 0)
+		if (const auto hullDropTotal = int(global->config->hullDropFactor * static_cast<float>(ship->fMass)); hullDropTotal > 0)
 		{
 			if (FLHookConfig::i()->general.debugMode)
 				Console::ConDebug(std::format("Cargo drop in system {:#X} at {:.2f}, {:.2f}, {:.2f} for ship size of shipSizeEst={} iHullDrop={}\n",
@@ -174,7 +174,7 @@ namespace Plugins::CargoDrop
 				    hullDropTotal));
 
 			for (const auto& cargo : global->playerOnDeathCargo)
-				Server.MineAsteroid(system, position, global->cargoDropContainerId, cargo, static_cast<int>(hullDropTotal), clientKiller);
+				Server.MineAsteroid(system, position, global->cargoDropContainerId, cargo, int(hullDropTotal), clientKiller);
 
 		}
 	}

--- a/plugins/cargo_drop/CargoDrop.cpp
+++ b/plugins/cargo_drop/CargoDrop.cpp
@@ -162,7 +162,7 @@ namespace Plugins::CargoDrop
 				}
 			}
 		}
-		if (const auto hullDropTotal = int(global->config->hullDropFactor * static_cast<float>(ship->fMass)); hullDropTotal > 0)
+		if (const auto hullDropTotal = int(global->config->hullDropFactor * float(ship->fMass)); hullDropTotal > 0)
 		{
 			if (FLHookConfig::i()->general.debugMode)
 				Console::ConDebug(std::format("Cargo drop in system {:#X} at {:.2f}, {:.2f}, {:.2f} for ship size of shipSizeEst={} iHullDrop={}\n",

--- a/plugins/cargo_drop/CargoDrop.cpp
+++ b/plugins/cargo_drop/CargoDrop.cpp
@@ -3,7 +3,7 @@
  * @author Cannon (Ported by Raikkonen 2022)
  * @defgroup CargoDrop Cargo Drop
  * @brief
- * The "Cargo Drop" plugin handles consequences to a player who disconnects whilst in space.
+ * The "Cargo Drop" plugin handles consequences for a player who disconnects whilst in space and allows servers to ensure that cargo items are dropped on player death rather than lost. Is also allows server owners to set additional commodities that are spawned as loot when a player ship dies based on hull mass (i.e. salvage).
  *
  * @paragraph cmds Player Commands
  * There are no player commands in this plugin.

--- a/plugins/cargo_drop/CargoDrop.cpp
+++ b/plugins/cargo_drop/CargoDrop.cpp
@@ -46,10 +46,14 @@ namespace Plugins::CargoDrop
 	{
 		auto config = Serializer::JsonToObject<Config>();
 		for (const auto& cargo : config.playerOnDeathCargo)
+		{
 			global->playerOnDeathCargo.push_back(CreateID(cargo.c_str()));
+		}
 
 		for (const auto& noLootItem : config.noLootItems)
+		{
 			global->noLootItemsIds.push_back(CreateID(noLootItem.c_str()));
+		}
 
 		global->config = std::make_unique<Config>(config);
 	}

--- a/plugins/cargo_drop/CargoDrop.cpp
+++ b/plugins/cargo_drop/CargoDrop.cpp
@@ -155,11 +155,10 @@ namespace Plugins::CargoDrop
 		{
 			for (const auto& [iId, count, archId, status, mission, mounted, hardpoint] : cargo.value())
 			{
-				if (!mounted)
+				if (!mounted && !mission && std::ranges::find(global->noLootItemsIds, archId) == global->noLootItemsIds.end())
+
 				{
-					if (!mission && std::ranges::find(global->noLootItemsIds, archId) == global->noLootItemsIds.end())
-						Server.MineAsteroid(
-						    system, position, global->cargoDropContainerId, archId, std::min(count, global->config->maxPlayerCargoDropCount), clientKiller);
+					Server.MineAsteroid(system, position, global->cargoDropContainerId, archId, std::min(count, global->config->maxPlayerCargoDropCount), clientKiller);
 				}
 			}
 		}

--- a/plugins/cargo_drop/CargoDrop.cpp
+++ b/plugins/cargo_drop/CargoDrop.cpp
@@ -173,8 +173,8 @@ namespace Plugins::CargoDrop
 				    ship->fMass,
 				    hullDropTotal));
 
-			for (const auto& cargo : global->playerOnDeathCargo)
-				Server.MineAsteroid(system, position, global->cargoDropContainerId, cargo, int(hullDropTotal), clientKiller);
+			for (const auto& playerCargo : global->playerOnDeathCargo)
+				Server.MineAsteroid(system, position, global->cargoDropContainerId, playerCargo, int(hullDropTotal), clientKiller);
 
 		}
 	}

--- a/plugins/cargo_drop/CargoDrop.h
+++ b/plugins/cargo_drop/CargoDrop.h
@@ -36,16 +36,14 @@ namespace Plugins::CargoDrop
 		int maxPlayerCargoDropCount = 3000; 
 		//! Distance used to decide if report/player death should occur based on proximity to other players.
 		float disconnectingPlayersRange = 5000.0f;
-		//! Ratio of ship's unused cargo space to 'ship parts' commodities left behind on death, specified in hullDrop1NickName and hullDrop2NickName.
+		//! Ratio of ship's mass space to 'ship parts' commodities left behind on death, specified in playerOnDeathCargo. The number of items dropped of each type is equal to ship mass multiplied by hullDropFactor.
 		float hullDropFactor = 0.1f;
 		//! Message broadcasted to nearby players upon disconnect if reportDisconnectingPlayers is true.
 		std::string disconnectMsg = "%player is attempting to engage cloaking device";
 		//! Nickname of loot container model containing cargo/ship parts left behind upon death/disconnection.
 		std::string cargoDropContainer = "lootcrate_ast_loot_metal";
-		//! Ship parts commodity left behind on death if hullDropFactor is above zero.
-		std::string hullDrop1NickName = "commodity_super_alloys";
-		//! Ship parts commodity left behind on death if hullDropFactor is above zero.
-		std::string hullDrop2NickName = "commodity_engine_components";
+		//! Contains a list of nicknames of items that will always be dropped into space when a player is destroyed if hullDropFactor is above zero.
+		std::vector<std::string> playerOnDeathCargo = {"commodity_super_alloys", "commodity_engine_components"};
 		//! Contains a list of nicknames of items that will not be dropped into space under any circumstances.
 		std::vector<std::string> noLootItems = {};
 	};
@@ -61,9 +59,13 @@ namespace Plugins::CargoDrop
 		std::map<uint, Info> info;
 		//! The id of the container to drop
 		uint cargoDropContainerId;
-		//! These two ids are commodities to represent the ship after destruction
-		uint hullDrop1NickNameId;
-		uint hullDrop2NickNameId;
+		//! This id is for commodities to represent the ship after destruction
+		std::vector<uint> playerOnDeathCargo;
+
+		//uint hullDrop1NickNameId;
+		//uint hullDrop2NickNameId;
+		//uint hullDrop3NickNameId;
+
 		//! Items we don't want to be looted
 		std::vector<uint> noLootItemsIds;
 	};

--- a/plugins/cargo_drop/CargoDrop.h
+++ b/plugins/cargo_drop/CargoDrop.h
@@ -61,11 +61,6 @@ namespace Plugins::CargoDrop
 		uint cargoDropContainerId;
 		//! This id is for commodities to represent the ship after destruction
 		std::vector<uint> playerOnDeathCargo;
-
-		//uint hullDrop1NickNameId;
-		//uint hullDrop2NickNameId;
-		//uint hullDrop3NickNameId;
-
 		//! Items we don't want to be looted
 		std::vector<uint> noLootItemsIds;
 	};


### PR DESCRIPTION
- Have changed the `hullDrop1NickNameId` and `hullDrop2NickNameId` fields to a single `playerOnDeathCargo` that can be populated with multiple commodities
- Drop quantities are now calculated as `fMass * hullDropFactor` rather than `remainingHoldSize * hullDropFactor * 0.5`. This seems like a more sensible approach to take to hull drops, and I intend to expand upon this in the future.