### PR TITLE
NPC Control: Fixes for #244, #253 and #319

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.0.8
+- Fix bugs with NPC Control Plugin.
+
 ## 4.0.7
 - Fix code smells shown in SonarLint.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 4.0.8
 - Fix bugs with NPC Control Plugin.
+- Fix bug with the chase admin command.
 
 ## 4.0.7
 - Fix code smells shown in SonarLint.

--- a/plugins/minecontrol/MiningControl.cpp
+++ b/plugins/minecontrol/MiningControl.cpp
@@ -448,7 +448,7 @@ namespace Plugins::MiningControl
 						uint sendToClientId = client;
 						if (!miningBonusEligible)
 						{
-							auto targetShip = Hk::Player::GetTarget(ship);
+							auto targetShip = Hk::Player::GetTarget(client);
 							if (targetShip.has_value())
 							{
 								const auto targetClientId = Hk::Client::GetClientIdByShip(targetShip.value());

--- a/plugins/npc_control/NPCControl.cpp
+++ b/plugins/npc_control/NPCControl.cpp
@@ -334,24 +334,21 @@ namespace Plugins::Npc
 		// Destroy targeted ship
 		if (cmds->IsPlayer())
 		{
-			if (auto const ship = Hk::Player::GetShip(Hk::Client::GetClientIdFromCharName(cmds->GetAdminName()).value()); ship.has_value())
-				if (auto const target = Hk::Player::GetTarget(ship.value()); target.has_value())
+			if (auto const target = Hk::Player::GetTarget(cmds->GetAdminName()); target.has_value())
+			{
+				if (const auto it = std::ranges::find(global->spawnedNpcs, target.value()); target.value() && it != global->spawnedNpcs.end())
 				{
-					if (const auto it = std::ranges::find(global->spawnedNpcs, target.value()); target.value() && it != global->spawnedNpcs.end())
-					{
-						pub::SpaceObj::Destroy(target.value(), DestroyType::FUSE);
-						global->spawnedNpcs.erase(it);
-						cmds->Print("OK");
-						return;
-					}
+					pub::SpaceObj::Destroy(target.value(), DestroyType::FUSE);
+					cmds->Print("OK");
+					return;
 				}
+			}
 		}
 
-		// Destroy all ships
-		for (const auto& npc : global->spawnedNpcs)
+		// Destroy all ships - Copy into new vector since the old one will be modified in ShipDestroy hook
+		for (std::vector<uint> tempSpawnedNpcs = global->spawnedNpcs; const auto& npc : tempSpawnedNpcs)
 			pub::SpaceObj::Destroy(npc, DestroyType::FUSE);
 
-		global->spawnedNpcs.clear();
 		cmds->Print("OK");
 	}
 

--- a/plugins/npc_control/NPCControl.cpp
+++ b/plugins/npc_control/NPCControl.cpp
@@ -426,12 +426,11 @@ namespace Plugins::Npc
 			const auto ship = Hk::Player::GetShip(client);
 			if (ship.has_value())
 			{
-				if (const auto target = Hk::Player::GetTarget(ship.value()); target.has_value())
+				if (const auto target = Hk::Player::GetTarget(client); target.has_value())
 				{
 					if (const auto it = std::ranges::find(global->spawnedNpcs, target.value()); target.value() && it != global->spawnedNpcs.end())
 					{
 						AiFollow(ship.value(), target.value());
-						global->spawnedNpcs.erase(it);
 					}
 					else
 					{
@@ -459,29 +458,25 @@ namespace Plugins::Npc
 			return;
 		}
 
-		const auto ship = Hk::Player::GetShip(Hk::Client::GetClientIdFromCharName(cmds->GetAdminName()).value());
-		if (ship.has_value())
+		// Is the admin targeting an NPC?
+		if (const auto target = Hk::Player::GetTarget(cmds->GetAdminName()); target.has_value())
 		{
-			// Is the admin targeting an NPC?
-			if (const auto target = Hk::Player::GetTarget(ship.value()); target.has_value())
+			if (const auto it = std::ranges::find(global->spawnedNpcs, target.value()); target.value() && it != global->spawnedNpcs.end())
 			{
-				if (const auto it = std::ranges::find(global->spawnedNpcs, target.value()); target.value() && it != global->spawnedNpcs.end())
-				{
-					pub::AI::DirectiveCancelOp cancelOp;
-					pub::AI::SubmitDirective(target.value(), &cancelOp);
-				}
+				pub::AI::DirectiveCancelOp cancelOp;
+				pub::AI::SubmitDirective(target.value(), &cancelOp);
 			}
-			// Cancel all NPC actions
-			else
-			{
-				for (const auto& npc : global->spawnedNpcs)
-				{
-					pub::AI::DirectiveCancelOp cancelOp;
-					pub::AI::SubmitDirective(npc, &cancelOp);
-				}
-			}
-			cmds->Print("OK");
 		}
+		// Cancel all NPC actions
+		else
+		{
+			for (const auto& npc : global->spawnedNpcs)
+			{
+				pub::AI::DirectiveCancelOp cancelOp;
+				pub::AI::SubmitDirective(npc, &cancelOp);
+			}
+		}
+		cmds->Print("OK");
 	}
 
 	/** @ingroup NPCControl

--- a/source/CCmds.cpp
+++ b/source/CCmds.cpp
@@ -811,17 +811,24 @@ void CCmds::CmdChase(std::wstring adminName, const std::variant<uint, std::wstri
 {
 	RIGHT_CHECK_SUPERADMIN();
 
-	if (const auto res = Hk::Admin::GetPlayerInfo(adminName, false);
-		res.has_error())
+	const auto admin = Hk::Admin::GetPlayerInfo(adminName, false);
+
+	if (admin.has_error())
 	{
-		PrintError(res.error());
+		PrintError(admin.error());
 		return;
 	}
 
 	const auto target = Hk::Admin::GetPlayerInfo(player, false);
 	if (target.has_error() || target.value().ship == 0)
 	{
-		Print("ERR Player not found or not in space");
+		Print("ERR Player not found or not in space.");
+		return;
+	}
+
+	if (target.value().iSystem != admin.value().iSystem)
+	{
+		Print("ERR Player must be in the same system as you.");
 		return;
 	}
 
@@ -830,7 +837,8 @@ void CCmds::CmdChase(std::wstring adminName, const std::variant<uint, std::wstri
 	pub::SpaceObj::GetLocation(target.value().ship, pos, ornt);
 	pos.y += 100;
 
-	Print(std::format("Jump to system={} x={:.0f} y={:.0f} z={:.0f}", wstos(target.value().wscSystem), pos.x, pos.y, pos.z));
+	Hk::Player::RelocateClient(admin.value().client, pos, ornt);
+
 	return;
 }
 

--- a/source/CCmds.cpp
+++ b/source/CCmds.cpp
@@ -948,14 +948,7 @@ std::wstring CCmds::ArgCharname(uint iArg)
 			return this->GetAdminName();
 		else if (bTarget)
 		{
-			auto client = Hk::Client::GetClientIdFromCharName(this->GetAdminName());
-			if (client.has_error())
-				return L"";
-			uint ship;
-			pub::Player::GetShip(client.value(), ship);
-			if (!ship)
-				return L"";
-			uint iTarget = Hk::Player::GetTarget(ship).value();
+			uint iTarget = Hk::Player::GetTarget(this->GetAdminName()).value();
 			if (!iTarget)
 				return L"";
 			auto targetId = Hk::Client::GetClientIdByShip(iTarget);
@@ -972,14 +965,7 @@ std::wstring CCmds::ArgCharname(uint iArg)
 			return L"id " + wscArg.substr(2);
 		else if (wscArg == L">t")
 		{
-			auto client = Hk::Client::GetClientIdFromCharName(this->GetAdminName());
-			if (client.has_error())
-				return L"";
-			uint ship;
-			pub::Player::GetShip(client.value(), ship);
-			if (!ship)
-				return L"";
-			uint iTarget = Hk::Player::GetTarget(ship).value();
+			uint iTarget = Hk::Player::GetTarget(this->GetAdminName()).value();
 			if (!iTarget)
 				return L"";
 			auto targetId = Hk::Client::GetClientIdByShip(iTarget);

--- a/source/CCmds.cpp
+++ b/source/CCmds.cpp
@@ -948,10 +948,10 @@ std::wstring CCmds::ArgCharname(uint iArg)
 			return this->GetAdminName();
 		else if (bTarget)
 		{
-			uint iTarget = Hk::Player::GetTarget(this->GetAdminName()).value();
-			if (!iTarget)
+			uint target = Hk::Player::GetTarget(this->GetAdminName()).value();
+			if (!target)
 				return L"";
-			auto targetId = Hk::Client::GetClientIdByShip(iTarget);
+			auto targetId = Hk::Client::GetClientIdByShip(target);
 			if (!targetId.has_error())
 				return L"";
 			return L"id " + std::to_wstring(targetId.value());
@@ -965,10 +965,10 @@ std::wstring CCmds::ArgCharname(uint iArg)
 			return L"id " + wscArg.substr(2);
 		else if (wscArg == L">t")
 		{
-			uint iTarget = Hk::Player::GetTarget(this->GetAdminName()).value();
-			if (!iTarget)
+			uint target = Hk::Player::GetTarget(this->GetAdminName()).value();
+			if (!target)
 				return L"";
-			auto targetId = Hk::Client::GetClientIdByShip(iTarget);
+			auto targetId = Hk::Client::GetClientIdByShip(target);
 			if (!targetId.has_error())
 				return L"";
 			return L"id " + std::to_wstring(targetId.value());


### PR DESCRIPTION
NPC Control: Fix for [#253](https://github.com/TheStarport/FLHook/issues/253). Wrong params for Hk::Player:GetTarget

NPC Control: Fix for [#244](https://github.com/TheStarport/FLHook/issues/244). We were removing NPCs from the vector twice.

Admin Commands: Fix for  [#319](https://github.com/TheStarport/FLHook/issues/319). Missing RelocateClient call, probably because Hyperjump used to handle that.