### PR TITLE
Addressed to-do: Ammo limits in Autobuy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.0.13
+- Adressed to-do in Autobuy: adhere to Ammo Limits specified in .ini files.
+
 ## 4.0.12
 - Fix the bugs reported in SonarCloud. This is mainly throwing a proper exception rather than just a string.
 

--- a/plugins/autobuy/Autobuy.cpp
+++ b/plugins/autobuy/Autobuy.cpp
@@ -57,7 +57,7 @@ namespace Plugins::Autobuy
 	int PlayerGetAmmoCount(const std::list<CARGO_INFO>& cargoList, uint itemArchId)
 	{
 		if (auto foundCargo = std::ranges::find_if(cargoList, [itemArchId](const CARGO_INFO& cargo) { return cargo.iArchId == itemArchId; });
-		    foundCargo != cargoList.end())
+		foundCargo != cargoList.end())
 		{
 			return foundCargo->iCount;
 		}
@@ -141,7 +141,7 @@ namespace Plugins::Autobuy
 	}
 
 	void AddEquipToCart(const Archetype::Launcher* launcher, const std::list<CARGO_INFO>& cargo, std::list<AutobuyCartItem>& cart, AutobuyCartItem& item,
-	    const std::wstring_view& desc)
+		const std::wstring_view& desc)
 	{
 		item.archId = launcher->iProjectileArchId;
 		uint itemId = Arch2Good(item.archId);
@@ -320,7 +320,7 @@ namespace Plugins::Autobuy
 		BaseInfo const* bi = nullptr;
 
 		if (auto foundBase = std::ranges::find_if(CoreGlobals::c()->allBases, [baseId](const BaseInfo& base) { return base.baseId == baseId; });
-		    foundBase != CoreGlobals::c()->allBases.end())
+			foundBase != CoreGlobals::c()->allBases.end())
 		{
 			bi = std::to_address(foundBase);
 		}
@@ -522,16 +522,16 @@ namespace Plugins::Autobuy
 
 	// Define usable chat commands here
 	const std::vector commands = {{
-	    CreateUserCommand(L"/autobuy", L"<consumable type/info> <on/off>", UserCmdAutobuy, L"Sets up automatic purchases for consumables."),
+		CreateUserCommand(L"/autobuy", L"<consumable type/info> <on/off>", UserCmdAutobuy, L"Sets up automatic purchases for consumables."),
 	}};
 
 	// Load Settings
 	void LoadSettings()
-    {
+	{
 		auto config = Serializer::JsonToObject<Config>();
 		global->config = std::make_unique<Config>(config);
 
-	    // Get ammo limit
+		// Get ammo limit
 		for (const auto& iniPath : global->config->iniPaths)
 		{
 			INI_Reader ini;
@@ -569,7 +569,7 @@ namespace Plugins::Autobuy
 				}
 			}
 		}
-    }
+	}
 } // namespace Plugins::Autobuy
 
 using namespace Plugins::Autobuy;

--- a/plugins/autobuy/Autobuy.cpp
+++ b/plugins/autobuy/Autobuy.cpp
@@ -143,12 +143,11 @@ namespace Plugins::Autobuy
 	void AddEquipToCart(const Archetype::Launcher* launcher, const std::list<CARGO_INFO>& cargo, std::list<AutobuyCartItem>& cart, AutobuyCartItem& item,
 	    const std::wstring_view& desc)
 	{
-		// TODO: Update to per-weapon ammo limits once implemented
 		item.archId = launcher->iProjectileArchId;
-		uint itemID = Arch2Good(item.archId);
+		uint itemId = Arch2Good(item.archId);
 		if (global->ammoLimits.find(Arch2Good(item.archId)) != global->ammoLimits.end())
 		{
-			item.count = global->ammoLimits[itemID] - PlayerGetAmmoCount(cargo, item.archId);
+			item.count = global->ammoLimits[itemId] - PlayerGetAmmoCount(cargo, item.archId);
 		}
 		else
 		{
@@ -546,8 +545,8 @@ namespace Plugins::Autobuy
 			{
 				if (ini.is_header("Munition"))
 				{
-					uint itemname;
-					int itemlimit;
+					uint itemname = 0;
+					int itemlimit = 0;
 					bool valid = false;
 
 					while (ini.read_value())
@@ -563,7 +562,7 @@ namespace Plugins::Autobuy
 						}
 					}
 
-					if (valid == true)
+					if (valid)
 					{
 						global->ammoLimits[itemname] = itemlimit;
 					}

--- a/plugins/autobuy/Autobuy.cpp
+++ b/plugins/autobuy/Autobuy.cpp
@@ -145,7 +145,7 @@ namespace Plugins::Autobuy
 	{
 		item.archId = launcher->iProjectileArchId;
 		uint itemId = Arch2Good(item.archId);
-		if (global->ammoLimits.find(Arch2Good(item.archId)) != global->ammoLimits.end())
+		if (global->ammoLimits.contains(Arch2Good(item.archId)))
 		{
 			item.count = global->ammoLimits[itemId] - PlayerGetAmmoCount(cargo, item.archId);
 		}
@@ -526,10 +526,10 @@ namespace Plugins::Autobuy
 	}};
 
 	// Load Settings
-    void LoadSettings()
+	void LoadSettings()
     {
-	    auto config = Serializer::JsonToObject<Config>();
-	    global->config = std::make_unique<Config>(config);
+		auto config = Serializer::JsonToObject<Config>();
+		global->config = std::make_unique<Config>(config);
 
 	    // Get ammo limit
 		for (const auto& iniPath : global->config->iniPaths)

--- a/plugins/autobuy/Autobuy.h
+++ b/plugins/autobuy/Autobuy.h
@@ -38,6 +38,18 @@ namespace Plugins::Autobuy
 		std::string nanobot_nickname = "ge_s_repair_01";
 		//! Nickname of the shield battery item being used when performing the automatic purchase
 		std::string shield_battery_nickname = "ge_s_battery_01";
+
+		// paths to inis which should be read for ammo limits
+		std::vector<std::string> iniPaths 
+		{
+			"..\\data\\equipment\\light_equip.ini",
+		    "..\\data\\equipment\\select_equip.ini",
+		    "..\\data\\equipment\\misc_equip.ini",
+		    "..\\data\\equipment\\engine_equip.ini",
+		    "..\\data\\equipment\\ST_equip.ini",
+		    "..\\data\\equipment\\weapon_equip.ini",
+		    "..\\data\\equipment\\prop_equip.ini"
+		};
 	};
 
 	struct Global final
@@ -45,6 +57,7 @@ namespace Plugins::Autobuy
 		std::unique_ptr<Config> config = nullptr;
 		std::map<uint, AutobuyInfo> autobuyInfo;
 		ReturnCode returnCode = ReturnCode::Default;
+		std::map<uint, int> ammoLimits;
 	};
 
 } // namespace Plugins::Autobuy

--- a/plugins/autobuy/Autobuy.h
+++ b/plugins/autobuy/Autobuy.h
@@ -42,13 +42,13 @@ namespace Plugins::Autobuy
 		// paths to inis which should be read for ammo limits
 		std::vector<std::string> iniPaths 
 		{
-			"..\\data\\equipment\\light_equip.ini",
-		    "..\\data\\equipment\\select_equip.ini",
-		    "..\\data\\equipment\\misc_equip.ini",
-		    "..\\data\\equipment\\engine_equip.ini",
-		    "..\\data\\equipment\\ST_equip.ini",
-		    "..\\data\\equipment\\weapon_equip.ini",
-		    "..\\data\\equipment\\prop_equip.ini"
+			R"(..\data\equipment\light_equip.ini)",
+			R"(..\data\equipment\select_equip.ini)",
+			R"(..\data\equipment\misc_equip.ini"),
+		    R"(..\data\equipment\engine_equip.ini)",
+		    R"(..\data\equipment\ST_equip.ini)",
+		    R"(..\data\equipment\weapon_equip.ini)",
+		    R"(..\data\equipment\prop_equip.ini)"
 		};
 	};
 
@@ -57,7 +57,7 @@ namespace Plugins::Autobuy
 		std::unique_ptr<Config> config = nullptr;
 		std::map<uint, AutobuyInfo> autobuyInfo;
 		ReturnCode returnCode = ReturnCode::Default;
-		std::map<uint, int> ammoLimits;
+		std::unordered_map<uint, int> ammoLimits;
 	};
 
 } // namespace Plugins::Autobuy


### PR DESCRIPTION
There is probably two Codesmells issues with my fix:
1. Excessive nesting in the plugin load function. Seems to me like there is no great way around this.
   (Except for using goto or a flag?) Suggestions are appreciated.
2. I am unsure what 'Cognitive Complexity' is referring to.

The change has been running & tested on bmod for a while already, so it should work fine.