### PR TITLE
Autobuy: Remove a PrintUserCmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.0.16
+- Removed a PrintUserCmd from Autobuy that was printing on every repair.
+
 ## 4.0.15
 - Fixed a typo in the Autobuy plugin header that caused incorrect configs to be generated.
 

--- a/plugins/autobuy/Autobuy.cpp
+++ b/plugins/autobuy/Autobuy.cpp
@@ -129,7 +129,6 @@ namespace Plugins::Autobuy
 				newColGrp->componentHP = 1.0f;
 				componentList.push_back(*newColGrp);
 			}
-			PrintUserCmdText(client, std::format(L"Attempting to repair {} components.", playerCollision.size()));
 			HookClient->Send_FLPACKET_SERVER_SETCOLLISIONGROUPS(client, componentList);
 		}
 


### PR DESCRIPTION
Remove this Print, this is not needed for the player and can be annoying