### PR TITLE
Remove unwanted offsets from CrashCatcher.cpp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.0.17
+- Remove modifications of 0x86AEC, 0x84018, 0xD3D6E and 0x58F46 in server.dll from crash catcher. These offsets were hardcoding several values that are often changed by mods manually relating to NPC spawn and scanner range.
+
 ## 4.0.16
 - Removed a PrintUserCmd from Autobuy that was printing on every repair.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 4.0.17
-- Remove modifications of 0x86AEC, 0x84018, 0xD3D6E and 0x58F46 in server.dll from crash catcher. These offsets were hardcoding several values that are often changed by mods manually relating to NPC spawn and scanner range.
+- Provided configs for 0x86AEC, 0x84018, 0xD3D6E and 0x58F46 in server.dll in crash catcher. These offsets were hardcoding several values that are often changed by mods manually relating to NPC spawn and scanner range. 0 values disables each respective hook.
 
 ## 4.0.16
 - Removed a PrintUserCmd from Autobuy that was printing on every repair.

--- a/plugins/crash_catcher/CrashCatcher.cpp
+++ b/plugins/crash_catcher/CrashCatcher.cpp
@@ -408,17 +408,6 @@ will_crash:
 				global->bPatchInstalled = true;
 
 				global->hModServerAC = GetModuleHandle("server.dll");
-				if (global->hModServerAC)
-				{
-					// Patch the NPC visibility distance in MP to 6.5km (default
-					// is 2.5km)
-					float fDistance = 6500.0f * 6500.0f;
-					WriteProcMem((char*)global->hModServerAC + 0x86AEC, &fDistance, 4);
-
-					FARPROC fpHook = (FARPROC)Cb_GetRoot;
-					ReadProcMem((char*)global->hModServerAC + 0x84018, &fpOldGetRootProc, 4);
-					WriteProcMem((char*)global->hModServerAC + 0x84018, &fpHook, 4);
-				}
 
 				// Patch the time functions to work around bugs on multiprocessor
 				// and virtual machines.
@@ -517,12 +506,6 @@ will_crash:
 					PatchCallAddr((char*)global->hModContentAC, 0xC702A, (char*)Cb_CrashProc6F671A0);
 					PatchCallAddr((char*)global->hModContentAC, 0xC713B, (char*)Cb_CrashProc6F671A0);
 					PatchCallAddr((char*)global->hModContentAC, 0xC7180, (char*)Cb_CrashProc6F671A0);
-
-					// Patch the NPC persist distance in MP to 6.5km and patch the
-					// max spawn distance to 6.5km
-					float fDistance = 6500;
-					WriteProcMem((char*)global->hModContentAC + 0xD3D6E, &fDistance, 4);
-					WriteProcMem((char*)global->hModContentAC + 0x58F46, &fDistance, 4);
 				}
 			}
 		}

--- a/plugins/crash_catcher/CrashCatcher.h
+++ b/plugins/crash_catcher/CrashCatcher.h
@@ -5,6 +5,20 @@
 
 namespace Plugins::CrashCatcher
 {
+
+	//! Config data for this plugin
+	struct Config final : Reflectable
+	{
+		std::string File() override { return "config/crashcatcher.json"; }
+
+		//! Sets the maximum distance at which NPCs become visible as per scanner settings, a value of 0 will disable this override.
+		float npcVisibilityDistance = 6500.f;
+		//! Sets the distnace at which NPCs will despawn, a value of 0 will disable this override.
+		float npcPersistDistance = 6500.f;
+		//! Sets the distance at which NPCs will spawn, a value of 0 will disable this override.
+		float npcSpawnDistance = 6500.f;
+	};
+
 	//! Global data for this plugin
 	struct Global final
 	{
@@ -18,12 +32,14 @@ namespace Plugins::CrashCatcher
 		HMODULE hModContentAC;
 
 		std::map<uint, mstime> mapSaveTimes;
+		//! Contains config data defined above
+		std::unique_ptr<Config> config = nullptr;
 	};
 
-	#define LOG_EXCEPTION_INTERNAL()								\
-	{																\
-		AddLogInternal("ERROR Exception in %s", __FUNCTION__);		\
-		AddExceptionInfoLog();										\
+#define LOG_EXCEPTION_INTERNAL()                               \
+	{                                                          \
+		AddLogInternal("ERROR Exception in %s", __FUNCTION__); \
+		AddExceptionInfoLog();                                 \
 	};
 } // namespace Plugins::CrashCatcher
 

--- a/plugins/crash_catcher/CrashCatcher.h
+++ b/plugins/crash_catcher/CrashCatcher.h
@@ -32,8 +32,6 @@ namespace Plugins::CrashCatcher
 		HMODULE hModContentAC;
 
 		std::map<uint, mstime> mapSaveTimes;
-		//! Contains config data defined above
-		std::unique_ptr<Config> config = nullptr;
 	};
 
 #define LOG_EXCEPTION_INTERNAL()                               \


### PR DESCRIPTION
I've removed offsets from CrashCatcher.cpp that relate to NPC spawn distance and maximum scan range. These offsets are often adjusted server-side by mods, and frustratingly, crash catcher removes them. This has caused problems before, both for BMOD and other mods in the past (https://the-starport.com/forums/topic/6165/npc-spawn-distance/2?_=1705854248325).

Changes here link to #327 and should be propagated to 4.1, I would suggest maybe sticking these patches in core with a config option for server owners.

The offset adjustments are made in server.dll and are as follows:

0x86AEC
0x84018
0xD3D6E
0x58F46