### PR TITLE
Sonar Scan Java Version Fix

### DIFF
--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -54,10 +54,10 @@ jobs:
             $number = Get-Content -Path pr-number.txt
             echo "PR_NUMBER=$number" >> $env:GITHUB_ENV
           }
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
       - uses: ilammy/msvc-dev-cmd@v1.10.0
         with:
           arch: x86

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 4.0.19
+- Updated the SonarScan to use version 17 of Java, as 11 is no longer working and causes the pipeline to fail.
 
 ## 4.0.18
 - Changed IServerImpl::RequestBestPath hook to use new BestPathInfo struct


### PR DESCRIPTION
Version 11 of the JDK is no longer working with the Sonar Scan pipeline, causing it to fail. 

The pipeline will run when this PR is submitted, so we'll see if this fixes it!