### PR TITLE
Daily Tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## 4.0.21
+- Create 'daily_tasks' a plugin that assigns basic daily tasks to player accounts for them to complete.
+
 ## 4.0.20
 - Fixed issue where repair cost was not fetched from base inis.
 - Fixed CargoDrop and Condata that wouldn't compile as a result of a breaking SDK change.

--- a/plugins/daily_tasks/DailyTasks.cpp
+++ b/plugins/daily_tasks/DailyTasks.cpp
@@ -1,0 +1,185 @@
+﻿// A plugin that assigns small tasks to players daily, and provides a random reward from a pool of items.
+//
+// This is free software; you can redistribute it and/or modify it as
+// you wish without restriction. If you do then I would appreciate
+// being notified and/or mentioned somewhere.
+
+// Includes
+#include "DailyTasks.hpp"
+
+#include <random>
+
+// TODO: Format strings for task descriptions
+
+namespace Plugins::DailyTasks
+{
+	const auto global = std::make_unique<Global>();
+
+	// Put things that are performed on plugin load here!
+	void LoadSettings()
+	{
+		// Load JSON config
+		auto config = Serializer::JsonToObject<Config>();
+		global->config = std::make_unique<Config>(std::move(config));
+
+		// Load the string DLLS
+		Hk::Message::LoadStringDLLs();
+
+		// TODO: Include taskTradeBaseTargets in this set of loops.
+		// Convert the config inputs into something we can work with.
+		for (const auto& [key, value] : global->config->itemRewardPool)
+		{
+			global->itemRewardPool[CreateID(key.c_str())] = value;
+		}
+		for (const auto& [key, value] : global->config->taskTradeItemTargets)
+		{
+			global->taskTradeItemTargets[CreateID(key.c_str())] = value;
+		}
+		for (const auto& [key, value] : global->config->taskItemAcquisitionTargets)
+		{
+			global->taskItemAcquisitionTargets[CreateID(key.c_str())] = value;
+		}
+		for (const auto& [key, value] : global->config->taskNpcKillTargets)
+		{
+			global->taskNpcKillTargets[CreateID(key.c_str())] = value;
+		}
+	}
+
+	// Function: Generates a random int between min and max
+	int RandomNumber(int min, int max)
+	{
+		static std::random_device dev;
+		static auto engine = std::mt19937(dev());
+		auto range = std::uniform_int_distribution(min, max);
+		return range(engine);
+	}
+
+	// Function: Picks a random key from a map
+	uint RandomIdKey(std::map<uint, std::vector<int>> map)
+	{
+		auto iterator = map.begin();
+		std::advance(iterator, RandomNumber(1, map.size()));
+		auto& outputId = iterator->first;
+		return outputId;
+	}
+
+	// Function: Keeps track of time.
+	void DailyTimerTick()
+	{
+		// TODO: Create and implement this function.
+	}
+	// Function: Generates a daily task.
+	void GenerateDailyTask()
+	{
+		std::vector<std::string> taskTypePool;
+		std::vector<std::string> rewardPool;
+
+		// Check if task config values are populated. If they're populated, add them to the pool.
+		if (!global->config->taskItemAcquisitionTargets.empty())
+		{
+			taskTypePool.emplace_back("Acquire Items");
+		}
+		if (!global->config->taskNpcKillTargets.empty())
+		{
+			taskTypePool.emplace_back("Kill NPCs");
+		}
+		if (!global->config->taskPlayerKillTargets.empty())
+		{
+			taskTypePool.emplace_back("Kill Players");
+		}
+		if (!global->config->taskTradeBaseTargets.empty() && !global->config->taskTradeItemTargets.empty())
+		{
+			taskTypePool.emplace_back("Sell Cargo");
+		}
+
+		// Check if taskTypePool is empty after these checks and if so throw an error in the console.
+		if (taskTypePool.empty())
+		{
+			AddLog(LogType::Normal, LogLevel::Err, "No tasks have been defined in daily_tasks.json");
+			return;
+		}
+
+		// Choose a random task from the availlable pool.
+		const auto& randomTask = taskTypePool[RandomNumber(1, taskTypePool.size())];
+
+		if (randomTask == "Acquire Items")
+		{
+			auto itemAcquisitionTarget = RandomIdKey(global->taskItemAcquisitionTargets);
+			auto itemQuantity =
+			    RandomNumber(global->taskItemAcquisitionTargets.at(itemAcquisitionTarget)[0], global->taskItemAcquisitionTargets.at(itemAcquisitionTarget)[1]);
+
+			auto taskDescription = "Acquire {} units of {}";
+		}
+		if (randomTask == "Kill NPCs")
+		{
+			auto npcFactionTarget = RandomIdKey(global->taskNpcKillTargets);
+			auto npcQuantity = RandomNumber(global->taskNpcKillTargets.at(npcFactionTarget)[0], global->taskNpcKillTargets.at(npcFactionTarget)[1]);
+
+			// Grab the faction data so it can be included in the taskDescription string.
+			uint npcFactionAffiliation;
+			pub::Reputation::GetAffiliation(npcFactionTarget, npcFactionAffiliation);
+			uint npcFactionIds;
+			pub::Reputation::GetGroupName(npcFactionAffiliation, npcFactionIds);
+			auto taskDescription = "Destroy {} ships belonging to {}";
+		}
+		if (randomTask == "Kill Players")
+		{
+			auto playerQuantity = RandomNumber(global->config->taskPlayerKillTargets[0], global->config->taskPlayerKillTargets[1]);
+			auto taskDescription = "Destroy {} player ships";
+		}
+		if (randomTask == "Sell Cargo")
+		{
+			// Pick a random base and a random item from the config pools.
+			auto tradeBaseTarget = global->config->taskTradeBaseTargets[RandomNumber(1, global->taskTradeBaseTargets.size())];
+			auto tradeItemTarget = RandomIdKey(global->taskTradeItemTargets);
+			auto tradeItemQuantity = RandomNumber(global->taskTradeItemTargets.at(tradeItemTarget)[0], global->taskTradeItemTargets.at(tradeItemTarget)[1]);
+			auto taskDescription = "Sell {} units of {} at {}";
+		}
+	}
+
+	// Function: Assigns a daily task to a character.
+	void AssignDailyTask()
+	{
+		// TODO: Create and implement this function.
+	}
+
+	// Function: A command to display the current daily tasks a player has.
+	void UserCmdShowDailyTasks(ClientId& client, const std::wstring& param)
+	{
+		// TODO: Create and implement this function.
+	}
+
+	// Function: A command to reset user tasks.
+	void UserCmdResetUserDailyTasks()
+	{
+		// TODO: Create and implement this function.
+	}
+
+	// Define usable chat commands here
+	const std::vector commands = {{
+	    CreateUserCommand(L"/showdailies", L"<number>", UserCmdShowDailyTasks, L"Shows a list of current daily tasks for the user"),
+	}};
+
+} // namespace Plugins::DailyTasks
+
+using namespace Plugins::DailyTasks;
+
+REFL_AUTO(type(Config), field(taskQuantity), field(taskResetAmount), field(minCreditsReward), field(maxCreditsReward), field(itemRewardPool),
+    field(taskTradeBaseTargets), field(taskTradeItemTargets), field(taskItemAcquisitionTargets), field(taskNpcKillTargets), field(taskPlayerKillTargets));
+
+DefaultDllMainSettings(LoadSettings);
+const std::vector<Timer> timers = {{DailyTimerTick, 3600}};
+extern "C" EXPORT void ExportPluginInfo(PluginInfo* pi)
+{
+	// Full name of your plugin
+	pi->name("Daily Tasks");
+	// Shortened name, all lower case, no spaces. Abbreviation when possible.
+	pi->shortName("dailytasks");
+	pi->mayUnload(true);
+	pi->commands(&commands);
+	pi->timers(&timers);
+	pi->returnCode(&global->returnCode);
+	pi->versionMajor(PluginMajorVersion::VERSION_04);
+	pi->versionMinor(PluginMinorVersion::VERSION_00);
+	pi->emplaceHook(HookedCall::FLHook__LoadSettings, &LoadSettings, HookStep::After);
+}

--- a/plugins/daily_tasks/DailyTasks.cpp
+++ b/plugins/daily_tasks/DailyTasks.cpp
@@ -6,8 +6,10 @@
 
 // Includes
 #include "DailyTasks.hpp"
-
+#include <ranges>
 #include <random>
+
+// TODO: Tasks only written when assigned for first time OR when a single task is completed to save file writes.
 
 namespace Plugins::DailyTasks
 {
@@ -49,7 +51,6 @@ namespace Plugins::DailyTasks
 		    LogLevel::Info,
 		    std::format("{} possible random daily tasks have been loaded into the pool.", static_cast<int>(global->taskTypePool.size())));
 
-		// TODO: Include taskTradeBaseTargets in this set of loops.
 		// Convert the config inputs into something we can work with.
 		for (const auto& [key, value] : global->config->itemRewardPool)
 		{
@@ -66,6 +67,10 @@ namespace Plugins::DailyTasks
 		for (const auto& [key, value] : global->config->taskNpcKillTargets)
 		{
 			global->taskNpcKillTargets[MakeId(key.c_str())] = value;
+		}
+		for (const auto& base : global->config->taskTradeBaseTargets)
+		{
+			global->taskTradeBaseTargets.emplace_back(CreateID(base.c_str()));
 		}
 	}
 
@@ -87,42 +92,65 @@ namespace Plugins::DailyTasks
 		return outputId;
 	}
 
-	// Function: Generates a reward
-	// std::map<uint, int> CreateReward()
-	//{
-	//	// TODO: Create and implement this function.
-	//}
-
 	// Function: Keeps track of time.
 	void DailyTimerTick()
 	{
-		// TODO: Create and implement this function.
+		int currentHour = std::chrono::duration_cast<std::chrono::hours>(std::chrono::system_clock::now().time_since_epoch()).count() % 24;
+		if (currentHour == global->config->resetTime || currentHour == global->config->resetTime + 1 || currentHour == global->config->resetTime + 2)
+		{
+			// TODO: Reset the daily tasks
+			// TODO: Single json file, account name tied to task
+		}
 	}
 
-	void SaveTaskStatus()
+	// Writes created and assigned tasks to the relevant account's json file.
+	void SaveTaskStatusToJson(CAccount* account)
 	{
-		// TODO: Create and implement this function.
+		auto& taskList = global->accountTasks.at(account);
+		auto taskJsonPath = Hk::Client::GetAccountDirName(account);
+
+		char szDataPath[MAX_PATH];
+		GetUserDataPath(szDataPath);
+		Serializer::SaveToJson(taskList, std::format("{}\\Accts\\MultiPlayer\\{}\\daily_tasks.json", szDataPath, wstos(taskJsonPath)));
+		AddLog(LogType::Normal,
+		    LogLevel::Debug,
+		    std::format("Saving a task status update to {}\\Accts\\MultiPlayer\\{}\\daily_tasks.json", szDataPath, wstos(taskJsonPath)));
+	}
+
+	// Loads tasks from an account's relevant json file and and checks the date against the current time.
+	void LoadTaskStatusFromJson(CAccount* account)
+	{
+		auto& taskList = global->accountTasks.at(account);
+		auto taskJsonPath = Hk::Client::GetAccountDirName(account);
+
+		char szDataPath[MAX_PATH];
+		GetUserDataPath(szDataPath);
+		auto obj = Serializer::JsonToObject<Tasks>(std::format("{}\\Accts\\MultiPlayer\\{}\\daily_tasks.json", szDataPath, wstos(taskJsonPath)), true);
+
+		// auto config = Serializer::JsonToObject<Config>();
+		// global->config = std::make_unique<Config>(std::move(config));
 	}
 
 	// Function: Brief hook on ship destroyed to see if a task needs to be updated.
 	void ShipDestroyed()
 	{
+		// TODO: Create and implement this function.
 	}
 
 	// Function: Brief hook on ship destroyed to see if a task needs to be updated.
 	void ItemSold()
 	{
+		// TODO: Create and implement this function.
 	}
-
+	// Function: Brief hook on item bought to see if a task needs to be updated.
 	void ItemAcquired()
 	{
+		// TODO: Create and implement this function.
 	}
 
-	// TODO: Remove client from this
 	// Function: Generates a daily task.
-	void GenerateDailyTask(ClientId& client)
+	void GenerateDailyTask(CAccount* account)
 	{
-		// TODO: Have these return json objects that can be written to a file in the player save directory?
 		// Choose and create a random task from the available pool.
 		const auto& randomTask = global->taskTypePool[RandomNumber(0, global->taskTypePool.size() - 1)];
 
@@ -135,6 +163,20 @@ namespace Plugins::DailyTasks
 			auto itemArch = Archetype::GetEquipment(itemAcquisitionTarget);
 			auto taskDescription = std::format("Acquire {} units of {}", itemQuantity, wstos(Hk::Message::GetWStringFromIdS(itemArch->iIdsName)));
 			AddLog(LogType::Normal, LogLevel::Debug, std::format("Creating an 'Acquire Items' task to '{}'", taskDescription));
+
+			Task task;
+			task.taskType = 0;
+			task.itemTarget = itemAcquisitionTarget;
+			task.quantity = itemQuantity;
+			task.taskDescription = taskDescription;
+			task.isCompleted = false;
+			task.setTime = Hk::Time::GetUnixSeconds();
+
+			if (!global->accountTasks.contains(account))
+			{
+				global->accountTasks[account] = {};
+			}
+			global->accountTasks[account].tasks.emplace_back(task);
 		}
 		if (randomTask == 1)
 		{
@@ -145,6 +187,20 @@ namespace Plugins::DailyTasks
 			pub::Reputation::GetGroupName(npcFactionTarget, npcFactionIds);
 			auto taskDescription = std::format("Destroy {} ships belonging to the {}", npcQuantity, wstos(Hk::Message::GetWStringFromIdS(npcFactionIds)));
 			AddLog(LogType::Normal, LogLevel::Debug, std::format("Creating a 'Kill NPCs' task to '{}'", taskDescription));
+
+			Task task;
+			task.taskType = 1;
+			task.npcFactionTarget = npcFactionTarget;
+			task.quantity = npcQuantity;
+			task.taskDescription = taskDescription;
+			task.isCompleted = false;
+			task.setTime = Hk::Time::GetUnixSeconds();
+
+			if (!global->accountTasks.contains(account))
+			{
+				global->accountTasks[account] = {};
+			}
+			global->accountTasks[account].tasks.emplace_back(task);
 		}
 		if (randomTask == 2)
 		{
@@ -152,33 +208,67 @@ namespace Plugins::DailyTasks
 			auto playerQuantity = RandomNumber(global->config->taskPlayerKillTargets[0], global->config->taskPlayerKillTargets[1]);
 			auto taskDescription = std::format("Destroy {} player ships", playerQuantity);
 			AddLog(LogType::Normal, LogLevel::Debug, std::format("Creating a 'Kill Players' task to '{}'", taskDescription));
+
+			Task task;
+			task.taskType = 2;
+			task.quantity = playerQuantity;
+			task.taskDescription = taskDescription;
+			task.isCompleted = false;
+			task.setTime = Hk::Time::GetUnixSeconds();
+
+			if (!global->accountTasks.contains(account))
+			{
+				global->accountTasks[account] = {};
+			}
+			global->accountTasks[account].tasks.emplace_back(task);
 		}
 		if (randomTask == 3)
 		{
 			// Create a trade task
-			const auto& tradeBaseTarget = global->config->taskTradeBaseTargets[RandomNumber(0, global->config->taskTradeBaseTargets.size())];
+			const auto& tradeBaseTarget = global->taskTradeBaseTargets[RandomNumber(0, global->taskTradeBaseTargets.size() - 1)];
 			auto tradeItemTarget = RandomIdKey(global->taskTradeItemTargets);
 			auto tradeItemQuantity = RandomNumber(global->taskTradeItemTargets.at(tradeItemTarget)[0], global->taskTradeItemTargets.at(tradeItemTarget)[1]);
-			auto baseArch = Universe::get_base(CreateID(tradeBaseTarget.c_str()));
+			auto baseArch = Universe::get_base(tradeBaseTarget);
 			auto itemArch = Archetype::GetEquipment(tradeItemTarget);
 			auto taskDescription = std::format("Sell {} units of {} at {}",
 			    tradeItemQuantity,
 			    wstos(Hk::Message::GetWStringFromIdS(itemArch->iIdsName)),
 			    wstos(Hk::Message::GetWStringFromIdS(baseArch->baseIdS)));
 			AddLog(LogType::Normal, LogLevel::Debug, std::format("Creating a 'Sell Cargo' task to '{}'", taskDescription));
-		}
-	}
 
-	// Function: Assigns a daily task to a character.
-	void AssignDailyTask(ClientId& client)
-	{
-		// TODO: Create and implement this function.
+			Task task;
+			task.taskType = 3;
+			task.baseTarget = tradeBaseTarget;
+			task.itemTarget = tradeItemTarget;
+			task.quantity = tradeItemQuantity;
+			task.taskDescription = taskDescription;
+			task.isCompleted = false;
+			task.setTime = Hk::Time::GetUnixSeconds();
+
+			if (!global->accountTasks.contains(account))
+			{
+				global->accountTasks[account] = {};
+			}
+			global->accountTasks[account].tasks.emplace_back(task);
+		}
 	}
 
 	// Function: A command to display the current daily tasks a player has.
 	void UserCmdShowDailyTasks(ClientId& client, const std::wstring& param)
 	{
-		// TODO: Create and implement this function.
+		auto account = Hk::Client::GetAccountByClientID(client);
+		PrintUserCmdText(client, L"CURRENT DAILY TASKS");
+		for (auto& task : global->accountTasks[account].tasks)
+		{
+			if (!task.isCompleted)
+			{
+				PrintUserCmdText(client, stows(task.taskDescription));
+			}
+			else
+			{
+				PrintUserCmdText(client, stows(task.taskDescription + "TASK COMPLETED"));
+			}
+		}
 	}
 
 	// Function: A command to reset user tasks.
@@ -187,11 +277,22 @@ namespace Plugins::DailyTasks
 		// TODO: Create and implement this function.
 	}
 
-	// TODO: Remove /gen
+	// Function: Hook on player login to assign and check tasks.
+	void OnLogin([[maybe_unused]] struct SLoginInfo const& li, ClientId& client)
+	{
+		auto account = Hk::Client::GetAccountByClientID(client);
+
+		for (int i = 0; i < global->config->taskQuantity; i++)
+		{
+			GenerateDailyTask(account);
+		}
+
+		SaveTaskStatusToJson(account);
+	}
+
 	// Define usable chat commands here
 	const std::vector commands = {{
 	    CreateUserCommand(L"/showdailies", L"", UserCmdShowDailyTasks, L"Shows a list of current daily tasks for the user"),
-	    CreateUserCommand(L"/gen", L"", GenerateDailyTask, L"Generates a daily task for testing"),
 	}};
 
 } // namespace Plugins::DailyTasks
@@ -200,6 +301,11 @@ using namespace Plugins::DailyTasks;
 
 REFL_AUTO(type(Config), field(taskQuantity), field(taskResetAmount), field(minCreditsReward), field(maxCreditsReward), field(itemRewardPool),
     field(taskTradeBaseTargets), field(taskTradeItemTargets), field(taskItemAcquisitionTargets), field(taskNpcKillTargets), field(taskPlayerKillTargets));
+
+REFL_AUTO(type(Tasks), field(tasks));
+
+REFL_AUTO(type(Task), field(taskType), field(quantity), field(itemTarget), field(baseTarget), field(npcFactionTarget), field(taskDescription),
+    field(isCompleted), field(setTime));
 
 DefaultDllMainSettings(LoadSettings);
 const std::vector<Timer> timers = {{DailyTimerTick, 3600}};
@@ -216,6 +322,7 @@ extern "C" EXPORT void ExportPluginInfo(PluginInfo* pi)
 	pi->versionMajor(PluginMajorVersion::VERSION_04);
 	pi->versionMinor(PluginMinorVersion::VERSION_00);
 	pi->emplaceHook(HookedCall::FLHook__LoadSettings, &LoadSettings, HookStep::After);
+	pi->emplaceHook(HookedCall::IServerImpl__Login, &OnLogin, HookStep::After);
 
 	// pi->emplaceHook(HookedCall::IEngine__ShipDestroyed, &ShipDestroyed);
 	// pi->emplaceHook(HookedCall::IServerImpl__GFGoodBuy, &ItemSold);

--- a/plugins/daily_tasks/DailyTasks.cpp
+++ b/plugins/daily_tasks/DailyTasks.cpp
@@ -23,19 +23,19 @@ namespace Plugins::DailyTasks
 		// Check if task config values are populated. If they're populated, add them to the pool.
 		if (!global->config->taskItemAcquisitionTargets.empty())
 		{
-			global->taskTypePool.emplace_back("Acquire Items");
+			global->taskTypePool.emplace_back(0);
 		}
 		if (!global->config->taskNpcKillTargets.empty())
 		{
-			global->taskTypePool.emplace_back("Kill NPCs");
+			global->taskTypePool.emplace_back(1);
 		}
 		if (!global->config->taskPlayerKillTargets.empty())
 		{
-			global->taskTypePool.emplace_back("Kill Players");
+			global->taskTypePool.emplace_back(2);
 		}
 		if (!global->config->taskTradeBaseTargets.empty() && !global->config->taskTradeItemTargets.empty())
 		{
-			global->taskTypePool.emplace_back("Sell Cargo");
+			global->taskTypePool.emplace_back(3);
 		}
 
 		// Check if taskTypePool is empty after these checks and if so throw an error in the console.
@@ -44,12 +44,10 @@ namespace Plugins::DailyTasks
 			AddLog(LogType::Normal, LogLevel::Err, "No tasks have been defined in daily_tasks.json. No daily tasks will be generated.");
 			return;
 		}
+
 		AddLog(LogType::Normal,
 		    LogLevel::Info,
 		    std::format("{} possible random daily tasks have been loaded into the pool.", static_cast<int>(global->taskTypePool.size())));
-
-		// Load the string DLLS
-		Hk::Message::LoadStringDLLs();
 
 		// TODO: Include taskTradeBaseTargets in this set of loops.
 		// Convert the config inputs into something we can work with.
@@ -89,6 +87,12 @@ namespace Plugins::DailyTasks
 		return outputId;
 	}
 
+	// Function: Generates a reward
+	// std::map<uint, int> CreateReward()
+	//{
+	//	// TODO: Create and implement this function.
+	//}
+
 	// Function: Keeps track of time.
 	void DailyTimerTick()
 	{
@@ -100,7 +104,7 @@ namespace Plugins::DailyTasks
 		// TODO: Create and implement this function.
 	}
 
-	//Function: Brief hook on ship destroyed to see if a task needs to be updated.
+	// Function: Brief hook on ship destroyed to see if a task needs to be updated.
 	void ShipDestroyed()
 	{
 	}
@@ -122,8 +126,9 @@ namespace Plugins::DailyTasks
 		// Choose and create a random task from the available pool.
 		const auto& randomTask = global->taskTypePool[RandomNumber(0, global->taskTypePool.size() - 1)];
 
-		if (randomTask == "Acquire Items")
+		if (randomTask == 0)
 		{
+			// Create an item acquisition task
 			auto itemAcquisitionTarget = RandomIdKey(global->taskItemAcquisitionTargets);
 			auto itemQuantity =
 			    RandomNumber(global->taskItemAcquisitionTargets.at(itemAcquisitionTarget)[0], global->taskItemAcquisitionTargets.at(itemAcquisitionTarget)[1]);
@@ -131,8 +136,9 @@ namespace Plugins::DailyTasks
 			auto taskDescription = std::format("Acquire {} units of {}", itemQuantity, wstos(Hk::Message::GetWStringFromIdS(itemArch->iIdsName)));
 			AddLog(LogType::Normal, LogLevel::Debug, std::format("Creating an 'Acquire Items' task to '{}'", taskDescription));
 		}
-		if (randomTask == "Kill NPCs")
+		if (randomTask == 1)
 		{
+			// Create an NPC kill task
 			const auto& npcFactionTarget = RandomIdKey(global->taskNpcKillTargets);
 			auto npcQuantity = RandomNumber(global->taskNpcKillTargets.at(npcFactionTarget)[0], global->taskNpcKillTargets.at(npcFactionTarget)[1]);
 			uint npcFactionIds;
@@ -140,14 +146,16 @@ namespace Plugins::DailyTasks
 			auto taskDescription = std::format("Destroy {} ships belonging to the {}", npcQuantity, wstos(Hk::Message::GetWStringFromIdS(npcFactionIds)));
 			AddLog(LogType::Normal, LogLevel::Debug, std::format("Creating a 'Kill NPCs' task to '{}'", taskDescription));
 		}
-		if (randomTask == "Kill Players")
+		if (randomTask == 2)
 		{
+			// Create a player kill task
 			auto playerQuantity = RandomNumber(global->config->taskPlayerKillTargets[0], global->config->taskPlayerKillTargets[1]);
 			auto taskDescription = std::format("Destroy {} player ships", playerQuantity);
 			AddLog(LogType::Normal, LogLevel::Debug, std::format("Creating a 'Kill Players' task to '{}'", taskDescription));
 		}
-		if (randomTask == "Sell Cargo")
+		if (randomTask == 3)
 		{
+			// Create a trade task
 			const auto& tradeBaseTarget = global->config->taskTradeBaseTargets[RandomNumber(0, global->config->taskTradeBaseTargets.size())];
 			auto tradeItemTarget = RandomIdKey(global->taskTradeItemTargets);
 			auto tradeItemQuantity = RandomNumber(global->taskTradeItemTargets.at(tradeItemTarget)[0], global->taskTradeItemTargets.at(tradeItemTarget)[1]);
@@ -209,8 +217,8 @@ extern "C" EXPORT void ExportPluginInfo(PluginInfo* pi)
 	pi->versionMinor(PluginMinorVersion::VERSION_00);
 	pi->emplaceHook(HookedCall::FLHook__LoadSettings, &LoadSettings, HookStep::After);
 
-	//pi->emplaceHook(HookedCall::IEngine__ShipDestroyed, &ShipDestroyed);
-	//pi->emplaceHook(HookedCall::IServerImpl__GFGoodBuy, &ItemSold);
-	//pi->emplaceHook(HookedCall::IServerImpl__GFGoodSell, &ItemAcquired);
-	//pi->emplaceHook(HookedCall::IServerImpl__TractorObjects, &ItemAcquired);
+	// pi->emplaceHook(HookedCall::IEngine__ShipDestroyed, &ShipDestroyed);
+	// pi->emplaceHook(HookedCall::IServerImpl__GFGoodBuy, &ItemSold);
+	// pi->emplaceHook(HookedCall::IServerImpl__GFGoodSell, &ItemAcquired);
+	// pi->emplaceHook(HookedCall::IServerImpl__TractorObjects, &ItemAcquired);
 }

--- a/plugins/daily_tasks/DailyTasks.filters
+++ b/plugins/daily_tasks/DailyTasks.filters
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FA737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB12AAAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="Main.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/plugins/daily_tasks/DailyTasks.hpp
+++ b/plugins/daily_tasks/DailyTasks.hpp
@@ -1,0 +1,48 @@
+﻿#pragma once
+
+#include <FLHook.hpp>
+#include <plugin.h>
+
+namespace Plugins::DailyTasks
+{
+	// Loadable json configuration
+	struct Config : Reflectable
+	{
+		std::string File() override { return "config/daily_tasks.json"; }
+		//! The number of times per day, a player may reset and reroll their assigned daily tasks.
+		int taskResetAmount = 1;
+		//! The number of randomly generated tasks a player will receive each day.
+		int taskQuantity = 3;
+		//! The minimum possible amount of credits that can be awarded for completing a daily task.
+		int minCreditsReward = 5000;
+		//! The maximum possible amount of credits that can be awarded for completing a daily task.
+		int maxCreditsReward = 10000;
+		//! A pool of possible item rewards for completing a daily task.
+		std::map<std::string, std::vector<int>> itemRewardPool {
+		    {{"commodity_luxury_consumer_goods"}, {{5}, {10}}}, {{"commodity_diamonds"}, {{25}, {40}}}, {{"commodity_alien_artifacts"}, {{10}, {25}}}};
+		//! Possible target bases for trade tasks.
+		std::vector<std::string> taskTradeBaseTargets {{"li03_01_base"}, {"li03_02_base"}, {"li03_03_base"}};
+		//! Possible target items and their minimum and maximum quantity for trade tasks.
+		std::map<std::string, std::vector<int>> taskTradeItemTargets {
+		    {{"commodity_cardamine"}, {{5}, {10}}}, {{"commodity_scrap_metal"}, {{25}, {40}}}, {{"commodity_construction_machinery"}, {{10}, {25}}}};
+		//! Possible options for item acquisition tasks. Parameters are item and quantity.
+		std::map<std::string, std::vector<int>> taskItemAcquisitionTargets {
+		    {{"commodity_optronics"}, {{3}, {5}}}, {{"commodity_super_alloys"}, {{10}, {15}}}, {{"commodity_mox_fuel"}, {{8}, {16}}}};
+		//! Possible options for NPC kill tasks. Parameters are target faction and quantity.
+		std::map<std::string, std::vector<int>> taskNpcKillTargets = {{{"fc_x_grp"}, {{3}, {5}}}, {{"li_n_grp"}, {{10}, {15}}}};
+		//! Possible options for player kill tasks. Parameters are minimum and maximum quantity of kills needed.
+		std::vector<int> taskPlayerKillTargets = {{1}, {3}};
+	};
+
+	struct Global
+	{
+		std::unique_ptr<Config> config = nullptr;
+		ReturnCode returnCode = ReturnCode::Default;
+		std::map<uint, bool> playerTaskAllocationStatus;
+		std::map<uint, std::vector<int>> itemRewardPool;
+		std::map<uint, std::vector<int>> taskTradeItemTargets;
+		std::map<uint, std::vector<int>> taskItemAcquisitionTargets;
+		std::map<uint, std::vector<int>> taskNpcKillTargets;
+		std::vector<uint> taskTradeBaseTargets;
+	};
+} // namespace Plugins::DailyTasks

--- a/plugins/daily_tasks/DailyTasks.hpp
+++ b/plugins/daily_tasks/DailyTasks.hpp
@@ -36,9 +36,17 @@ namespace Plugins::DailyTasks
 		int taskDuration = 86400;
 	};
 
+	enum class TaskType
+	{
+		GetItem,
+		KillNpc,
+		KillPlayer,
+		SellItem
+	};
+
 	struct Task : Reflectable
 	{
-		int taskType = 0;
+		TaskType taskType = TaskType::GetItem;
 		int quantity = 0;
 		int quantityCompleted = 0;
 		uint itemTarget = 0;
@@ -64,7 +72,7 @@ namespace Plugins::DailyTasks
 		std::map<uint, std::vector<int>> taskItemAcquisitionTargets;
 		std::map<uint, std::vector<int>> taskNpcKillTargets;
 		std::vector<uint> taskTradeBaseTargets;
-		std::vector<int> taskTypePool;
+		std::vector<TaskType> taskTypePool;
 		std::map<CAccount*, Tasks> accountTasks;
 		std::map<CAccount*, bool> tasksReset;
 		bool dailyReset;

--- a/plugins/daily_tasks/DailyTasks.hpp
+++ b/plugins/daily_tasks/DailyTasks.hpp
@@ -32,6 +32,25 @@ namespace Plugins::DailyTasks
 		std::map<std::string, std::vector<int>> taskNpcKillTargets = {{{"fc_x_grp"}, {{3}, {5}}}, {{"li_n_grp"}, {{10}, {15}}}};
 		//! Possible options for player kill tasks. Parameters are minimum and maximum quantity of kills needed.
 		std::vector<int> taskPlayerKillTargets = {{1}, {3}};
+		//! The server time at which daily tasks will reset.
+		int resetTime = 12;
+	};
+
+	struct Task : Reflectable
+	{
+		int taskType = 0;
+		int quantity = 0;
+		uint itemTarget = 0;
+		uint baseTarget = 0;
+		uint npcFactionTarget = 0;
+		std::string taskDescription;
+		bool isCompleted = false;
+		uint setTime = 0;
+	};
+
+	struct Tasks : Reflectable
+	{
+		std::vector<Task> tasks;
 	};
 
 	struct Global
@@ -44,5 +63,7 @@ namespace Plugins::DailyTasks
 		std::map<uint, std::vector<int>> taskItemAcquisitionTargets;
 		std::map<uint, std::vector<int>> taskNpcKillTargets;
 		std::vector<uint> taskTradeBaseTargets;
+		std::vector<int> taskTypePool;
+		std::map<CAccount*, Tasks> accountTasks;
 	};
 } // namespace Plugins::DailyTasks

--- a/plugins/daily_tasks/DailyTasks.hpp
+++ b/plugins/daily_tasks/DailyTasks.hpp
@@ -9,8 +9,6 @@ namespace Plugins::DailyTasks
 	struct Config : Reflectable
 	{
 		std::string File() override { return "config/daily_tasks.json"; }
-		//! The number of times per day, a player may reset and reroll their assigned daily tasks.
-		int taskResetAmount = 1;
 		//! The number of randomly generated tasks a player will receive each day.
 		int taskQuantity = 3;
 		//! The minimum possible amount of credits that can be awarded for completing a daily task.
@@ -32,14 +30,17 @@ namespace Plugins::DailyTasks
 		std::map<std::string, std::vector<int>> taskNpcKillTargets = {{{"fc_x_grp"}, {{3}, {5}}}, {{"li_n_grp"}, {{10}, {15}}}};
 		//! Possible options for player kill tasks. Parameters are minimum and maximum quantity of kills needed.
 		std::vector<int> taskPlayerKillTargets = {{1}, {3}};
-		//! The server time at which daily tasks will reset.
+		//! The server hour at which players will be able to use the reset tasks command again.
 		int resetTime = 12;
+		//! The amount of time in seconds a player has to complete a set of assigned tasks before they get cleaned up during the hourly check or at login.
+		int taskDuration = 86400;
 	};
 
 	struct Task : Reflectable
 	{
 		int taskType = 0;
 		int quantity = 0;
+		int quantityCompleted = 0;
 		uint itemTarget = 0;
 		uint baseTarget = 0;
 		uint npcFactionTarget = 0;
@@ -65,5 +66,7 @@ namespace Plugins::DailyTasks
 		std::vector<uint> taskTradeBaseTargets;
 		std::vector<int> taskTypePool;
 		std::map<CAccount*, Tasks> accountTasks;
+		std::map<CAccount*, bool> tasksReset;
+		bool dailyReset;
 	};
 } // namespace Plugins::DailyTasks

--- a/plugins/daily_tasks/DailyTasks.hpp
+++ b/plugins/daily_tasks/DailyTasks.hpp
@@ -76,5 +76,6 @@ namespace Plugins::DailyTasks
 		std::map<CAccount*, Tasks> accountTasks;
 		std::map<CAccount*, bool> tasksReset;
 		bool dailyReset;
+		std::map<uint, float> goodList;
 	};
 } // namespace Plugins::DailyTasks

--- a/plugins/daily_tasks/DailyTasks.vcxproj
+++ b/plugins/daily_tasks/DailyTasks.vcxproj
@@ -1,0 +1,87 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="ReleaseWithDebug|Win32">
+      <Configuration>ReleaseWithDebug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{4270E660-9DF3-4BB3-B55D-5107824D9D10}</ProjectGuid>
+    <RootNamespace>$projectname$</RootNamespace>
+    <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v143</PlatformToolset>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseWithDebug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v143</PlatformToolset>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+    <Import Project="..\..\project\Common.props" />
+    <Import Project="..\Plugin Common.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseWithDebug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+    <Import Project="..\..\project\Common.props" />
+    <Import Project="..\Plugin Common.props" />
+  </ImportGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <TargetName>daily_tasks</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseWithDebug|Win32'">
+    <TargetName>daily_tasks</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>SERVER;_VC80_UPGRADE=0x0710;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <ConformanceMode>true</ConformanceMode>
+      <EnableModules>true</EnableModules>
+      <DisableSpecificWarnings>5222</DisableSpecificWarnings>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseWithDebug|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>SERVER;_VC80_UPGRADE=0x0710;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <ConformanceMode>true</ConformanceMode>
+      <EnableModules>true</EnableModules>
+      <DisableSpecificWarnings>5222</DisableSpecificWarnings>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <PropertyGroup Label="Vcpkg">
+    <VcpkgEnableManifest>true</VcpkgEnableManifest>
+  </PropertyGroup>
+  <ItemGroup>
+    <ClCompile Include="DailyTasks.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\project\FLHook.vcxproj">
+      <Project>{fe6eb3c9-da22-4492-aec3-068c9553a623}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="DailyTasks.hpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/plugins/daily_tasks/DailyTasks.vstemplate
+++ b/plugins/daily_tasks/DailyTasks.vstemplate
@@ -1,0 +1,25 @@
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Project">
+  <TemplateData>
+    <Name>FLHook Plugin Template</Name>
+    <Description>Create a basic flhook plugin to get started.</Description>
+    <ProjectType>VC</ProjectType>
+    <ProjectSubType>
+    </ProjectSubType>
+    <SortOrder>1000</SortOrder>
+    <CreateNewFolder>true</CreateNewFolder>
+    <DefaultName>PluginTemplate</DefaultName>
+    <ProvideDefaultName>true</ProvideDefaultName>
+    <LocationField>Enabled</LocationField>
+    <EnableLocationBrowseButton>true</EnableLocationBrowseButton>
+    <Icon>Icon.ico</Icon>
+    <LanguageTag>cpp</LanguageTag>
+    <PlatformTag>windows</PlatformTag>
+    <ProjectTypeTag>library</ProjectTypeTag>
+  </TemplateData>
+  <TemplateContent>
+    <Project TargetFileName="PluginTemplate.vcxproj" File="PluginTemplate.vcxproj" ReplaceParameters="true">
+      <ProjectItem ReplaceParameters="true" TargetFileName="Main.cpp">Main.cpp</ProjectItem>
+      <ProjectItem ReplaceParameters="false" TargetFileName="Main.hpp">Main.hpp</ProjectItem>
+    </Project>
+  </TemplateContent>
+</VSTemplate>

--- a/project/FLHook.sln
+++ b/project/FLHook.sln
@@ -84,6 +84,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Kill Tracker", "..\plugins\
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Loot Tables", "..\plugins\loot_tables\Loot Tables.vcxproj", "{DECED50E-AEE2-4327-94FC-6DAAEA6D8B61}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "DailyTasks", "..\plugins\daily_tasks\DailyTasks.vcxproj", "{4270E660-9DF3-4BB3-B55D-5107824D9D10}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Release|Win32 = Release|Win32
@@ -290,6 +292,14 @@ Global
 		{DECED50E-AEE2-4327-94FC-6DAAEA6D8B61}.ReleaseWithDebug|Win32.Build.0 = ReleaseWithDebug|Win32
 		{DECED50E-AEE2-4327-94FC-6DAAEA6D8B61}.ReleaseWithDebug|x64.ActiveCfg = ReleaseWithDebug|Win32
 		{DECED50E-AEE2-4327-94FC-6DAAEA6D8B61}.ReleaseWithDebug|x64.Build.0 = ReleaseWithDebug|Win32
+		{4270E660-9DF3-4BB3-B55D-5107824D9D10}.Release|Win32.ActiveCfg = Release|Win32
+		{4270E660-9DF3-4BB3-B55D-5107824D9D10}.Release|Win32.Build.0 = Release|Win32
+		{4270E660-9DF3-4BB3-B55D-5107824D9D10}.Release|x64.ActiveCfg = Release|Win32
+		{4270E660-9DF3-4BB3-B55D-5107824D9D10}.Release|x64.Build.0 = Release|Win32
+		{4270E660-9DF3-4BB3-B55D-5107824D9D10}.ReleaseWithDebug|Win32.ActiveCfg = ReleaseWithDebug|Win32
+		{4270E660-9DF3-4BB3-B55D-5107824D9D10}.ReleaseWithDebug|Win32.Build.0 = ReleaseWithDebug|Win32
+		{4270E660-9DF3-4BB3-B55D-5107824D9D10}.ReleaseWithDebug|x64.ActiveCfg = ReleaseWithDebug|Win32
+		{4270E660-9DF3-4BB3-B55D-5107824D9D10}.ReleaseWithDebug|x64.Build.0 = ReleaseWithDebug|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -328,6 +338,7 @@ Global
 		{681DDE36-BA92-48DB-92E8-4E821B92B4BA} = {88754785-84CA-4F78-8906-F8C39564BA83}
 		{91E8438D-F413-4A2C-8A9B-6CE3544116DB} = {88754785-84CA-4F78-8906-F8C39564BA83}
 		{DECED50E-AEE2-4327-94FC-6DAAEA6D8B61} = {88754785-84CA-4F78-8906-F8C39564BA83}
+		{4270E660-9DF3-4BB3-B55D-5107824D9D10} = {88754785-84CA-4F78-8906-F8C39564BA83}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BAC9ADCA-E201-4AA0-8494-1C3804461C24}


### PR DESCRIPTION
- Creates the daily_tasks plugin a plugin that assigns basic daily tasks to player accounts for them to complete.
- Comes with 4 configurable tasks: Kill players, kill NPCs of a certain faction, Sell cargo at a specific base, buy cargo
- Rewards are randomly generated and can assign a random amount of credits and commodities, all of this can be adjusted via the config file.