### PR TITLE
Irateredkite/solar ipc interface fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 4.0.32
+- Properly expose data for CreateUserDefinedSolarFormation() so objects spawned this way can be tracked by other plugins.
+
+## 4.0.31
+- Fixed a case in Advanced Startup Solars where randomly placed solars could occupy the same position
+
 ## 4.0.30
 - Adjusted the project file to ensure that Advanced Startup Solars is properly included in the build
 

--- a/plugins/solar_control/SolarControl.cpp
+++ b/plugins/solar_control/SolarControl.cpp
@@ -363,10 +363,6 @@ namespace Plugins::SolarControl
 	{
 		std::vector<uint> formationSpaceIds;
 
-		// TODO: Use find
-		// auto group = solararchformation.find(formation)
-		// returns an iterator
-
 		auto group = global->config->solarArchFormations.find(formation);
 
 		if (group == global->config->solarArchFormations.end())

--- a/plugins/solar_control/SolarControl.h
+++ b/plugins/solar_control/SolarControl.h
@@ -64,7 +64,7 @@ namespace Plugins::SolarControl
 		explicit SolarCommunicator(const std::string& plug);
 
 		uint PluginCall(CreateSolar, const std::wstring& name, Vector position, const Matrix& rotation, SystemId system, bool varyPosition, bool mission);
-		void PluginCall(CreateSolarFormation, const std::wstring& formation, const Vector& position, uint system);
+		std::vector<uint> PluginCall(CreateSolarFormation, const std::wstring& formation, const Vector& position, uint system);
 	};
 
 	//! Global data for this plugin


### PR DESCRIPTION
Ensure that the create formation function returns a vector of uint so spawned objects can be properly tracked by plugins. This should be merged after #424  