### PR TITLE
Make command matching require either the end of the string or a space following a command

### DIFF
--- a/include/Core/Commands/AbstractAdminCommandProcessor.hpp
+++ b/include/Core/Commands/AbstractAdminCommandProcessor.hpp
@@ -125,7 +125,7 @@ concept IsAdminCommandProcessor = std::is_base_of_v<AbstractAdminCommandProcesso
         const AdminCommandInfo<class>& command = std::get<N - 1>(class ::commandArray);                                                                      \
         for (auto& str : command.cmd)                                                                                                                        \
         {                                                                                                                                                    \
-            if (cmd.starts_with(str))                                                                                                                        \
+            if (cmd.starts_with(std::wstring(str) + L' ') || cmd == str)                                                                                     \
             {                                                                                                                                                \
                 paramVector.erase(paramVector.begin(), paramVector.begin() + (std::clamp(std::ranges::count(str, L' '), 1, 5)));                             \
                 return command.func(processor, paramVector);                                                                                                 \

--- a/include/Core/Commands/AbstractUserCommandProcessor.hpp
+++ b/include/Core/Commands/AbstractUserCommandProcessor.hpp
@@ -51,7 +51,7 @@ struct CommandInfo
         const CommandInfo<class> command = std::get<N - 1>(class ::commandArray);                                                                           \
         for (auto& str : command.cmd)                                                                                                                       \
         {                                                                                                                                                   \
-            if (cmd.starts_with(str))                                                                                                                       \
+            if (cmd.starts_with(std::wstring(str) + L' ') || cmd == str)                                                                                    \
             {                                                                                                                                               \
                 const auto countVal = std::ranges::count(str, L' ');                                                                                        \
                 paramVector.erase(paramVector.begin() + 1, paramVector.begin() + std::clamp(countVal + 2, 2, 6));                                           \

--- a/include/Core/Commands/AdminCommandProcessor.hpp
+++ b/include/Core/Commands/AdminCommandProcessor.hpp
@@ -113,7 +113,7 @@ class AdminCommandProcessor final : public Singleton<AdminCommandProcessor>, pub
         {
             for (const auto& command = std::get<N - 1>(commands); auto& str : command.cmd)
             {
-                if (cmd.starts_with(str))
+                if (cmd.starts_with(std::wstring(str) + L' ') || cmd == str)
                 {
                     if (const auto validation = Validate(user, command.allowedContext, command.requiredRole); validation.has_error())
                     {

--- a/include/Core/Commands/UserCommandProcessor.hpp
+++ b/include/Core/Commands/UserCommandProcessor.hpp
@@ -92,7 +92,7 @@ class UserCommandProcessor final : public Singleton<UserCommandProcessor>, publi
             const CommandInfo<UserCommandProcessor>& command = std::get<N - 1>(commands);
             for (const auto str : command.cmd)
             {
-                if (cmd.starts_with(str))
+                if (cmd.starts_with(std::wstring(str) + L' ') || cmd == str)
                 {
                     const auto countVal = std::ranges::count(str, L' ');
                     paramVector.erase(paramVector.begin() + 1, paramVector.begin() + std::clamp(countVal + 2, 2, 6));


### PR DESCRIPTION
Right now we're doing simple prefix matching, which means any junk immediately following /h or /t or /? or similar will result in that command being run, even without a space.