### PR TITLE
Prevent negative values going into unsigned types

### DIFF
--- a/include/API/Utils/TransformArgs.hpp
+++ b/include/API/Utils/TransformArgs.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "Exceptions/InvalidParameterException.hpp"
 
 // NOLINTBEGIN(*-identifier-length)
 template <typename Test, template <typename...> class Ref>
@@ -17,6 +18,11 @@ template <typename T>
     requires std::is_arithmetic_v<T>
 T TransformArg(std::wstring_view s, size_t paramNumber)
 {
+    if (std::is_unsigned_v<T> && s.size() > 0 && s[0] == '-')
+    {
+        // trying to put a negative number into an unsigned type
+        throw InvalidParameterException(s, paramNumber);
+    }
     return StringUtils::Cast<T>(s);
 }
 


### PR DESCRIPTION
For example, as the second parameter to /setmsg.