### PR TITLE
fix: various bugs around transferchar

### DIFF
--- a/source/API/FLHook/Database/AccountDatabase.cpp
+++ b/source/API/FLHook/Database/AccountDatabase.cpp
@@ -487,6 +487,8 @@ concurrencpp::result<std::wstring> AccountManager::TransferCharacter(const Accou
         {
             session.abort_transaction();
             err = L"Character or transfer code was incorrect";
+            THREAD_MAIN;
+            co_return err;
         }
 
         const auto transferCharacterOid = transferredCharacterDoc->find("_id")->get_oid();

--- a/source/Core/Commands/UserCommandProcessor.cpp
+++ b/source/Core/Commands/UserCommandProcessor.cpp
@@ -721,16 +721,16 @@ concurrencpp::result<void> UserCommandProcessor::TransferCharacter(const ClientI
 
         const AccountId accountId = client.GetAccount().Handle();
 
-        const std::wstring charName = param1.data();
-        const std::wstring charCode = param2.data();
+        const std::wstring charName = std::wstring(param1);
+        const std::wstring charCode = std::wstring(param2);
 
-        if (const auto err = co_await AccountManager::TransferCharacter(accountId, charName, charCode); err.empty())
+        if (const auto err = co_await AccountManager::TransferCharacter(accountId, charName, charCode); !err.empty())
         {
             (void)client.Message(err);
         }
         else
         {
-            (void)client.Kick(L"Transferring the character, you will be kicked.", 3);
+            (void)client.Kick(L"Transferring the character.", 3);
         }
     }
     else


### PR DESCRIPTION
* Add missing return to AccountManager::TransferCharacter so we stop before `transferredCharacterDoc->find("_id")` can crash the server.
* Use std::wstring(param1) instead of param1.data() so we don't effectively get param1 + param2, as that includes the code and will almost always fail.
* Fix checking the return value of AccountManager::TransferCharacter to not be backwards.
* Don't repeat part of the generic kick message in the kick message, it is redundant.