### PR TITLE
Don't crash when someone tries to log in an account twice simultaneously

### DIFF
--- a/source/API/FLHook/Database/AccountManager.cpp
+++ b/source/API/FLHook/Database/AccountManager.cpp
@@ -1067,6 +1067,15 @@ AccountManager::AccountManager()
 void AccountManager::ClearClientInfo(ClientId client)
 {
     auto& account = accounts.at(client.GetValue());
+    for (auto& next : FLHook::Clients())
+    {
+        if (next.id != client && account.account._id == next.account->_id)
+        {
+            // If there's another player logged into this account, don't erase anything.
+            // We ironically need to keep the loggedInAccounts data here to detect and *prevent* duplicate account login scenarios.
+            return;
+        }
+    }
     loggedInAccounts.erase(account.account._id);
     account.characters.clear();
 }

--- a/source/Hooks/ClientServerInterface/Login.cpp
+++ b/source/Hooks/ClientServerInterface/Login.cpp
@@ -18,8 +18,17 @@ void IServerImplHook::LoginInnerAfter(const SLoginInfo& li, ClientId client)
             return; // DisconnectDelay bug
         }
 
-        // Copy over admin information, if applicable
         auto& clientData = client.GetData();
+
+        if (!clientData.account)
+        {
+            // This can happen if a player tries to log into an account which
+            // is already in use - we need to protect ourselves before
+            // following the clientData.account pointer below
+            return;
+        }
+
+        // Copy over admin information, if applicable
         auto& credentials = FLHook::instance->credentialsMap[client] = {};
         if (const auto& roles = clientData.account->gameRoles; roles.has_value())
         {


### PR DESCRIPTION
This has two parts:
* Firstly, in IServerImplHook::LoginInnerAfter, don't follow the clientData.account pointer if it's not valid. This fixes the obvious bug.
* Secondly, in AccountManager::ClearClientInfo, be cautious regarding cleanup. It was trying to clean up all account data for a specific client leaving, but in duplicate login scenarios this would result in the removal of the loggedInAccounts record for the currently-logged-in client, meaning only the first duplicate login attempt would be prevented - it would wipe the records, and then clients were free to log in regardless as there was no longer a loggedInAccounts entry.