### PR TITLE
Reduce code duplication in AccountDatabase.cpp

### DIFF
--- a/include/API/FLHook/AccountManager.hpp
+++ b/include/API/FLHook/AccountManager.hpp
@@ -151,6 +151,9 @@ class AccountManager
         PlayerDbLoadUserDataAssembly loadUserDataAssembly;
 
     public:
+        static concurrencpp::result<bool> UpdateCharacter(std::wstring charName, bsoncxx::v_noabi::document::value charUpdateDoc,
+                                                          std::string logDescription);
+
         AccountManager();
         AccountManager(const AccountManager&) = delete;
         AccountManager& operator=(const AccountManager&) = delete;


### PR DESCRIPTION
A common pattern was to do a character existence check and run an update on the resulting record. This moves most of that logic, barring the update BSON document creation, into a central function.

This resolves the code quality issue flagged in #464. I had issues at the time creating a function that could accept BSON objects, but I have managed to sneak this one past the compiler. (I am not a C++ expert).